### PR TITLE
[Feature] Upgrades flow

### DIFF
--- a/docs/flows/flows.puml
+++ b/docs/flows/flows.puml
@@ -140,8 +140,17 @@ autonumber "Upgrades:[00]"
 
 == Upgrades ==
 
+bitdaoadmin -> governanceproxy: deploy proxy and set initial implementation
+bitdaoadmin -> treasuryproxy: deploy proxy and set initial implementation
+bitdaoadmin -> executorproxy: deploy proxy and set initial implementation
+
+
+alice -> bitdaogovernance: deploy new bitdaogovernance implementation
+alice -> bitdaotreasury: deploy new bitdaotreasury implementation
+alice -> executor: deploy new executor implementation
+
 alice -> forum: create forum upgrade proposal
-alice <- guarantor: positive/negative feedback
+alice <- community: positive/negative feedback
 
 community -> community: delegate role based votes
 
@@ -149,8 +158,9 @@ alice -> bitdaogovernance: if (roles) submit upgrade proposal
 community -> bitdaogovernance: roles voting
 
 bitdaoadmin -> bitdaogovernance: show roles voting result
-bitdaoadmin <-- bitdaogovernance: pass/fail
+bitdaoadmin <-- bitdaogovernance: pass
 
+bitdaoadmin -> bitdaogovernance: start execution
 executor <-- bitdaogovernance: execute proposal
 executor -> governanceproxy: set new bitdaogovernance implementation
 executor -> treasuryproxy: set new bitdaotreasury implementation

--- a/docs/flows/flows.puml
+++ b/docs/flows/flows.puml
@@ -26,9 +26,13 @@ database Snapshot as snapshot
 end box
 
 box "(onchain)" #Lavender
+collections Executor as executor
 collections BondContract as bondcontract
 collections GrantsTreasury as grantstreasury
 collections BitDAOTreasury as bitdaotreasury
+collections BitDAOGovernanceProxy as governanceproxy
+collections BitDAOTreasuryProxy as treasuryproxy
+collections ExecutorProxy as executorproxy
 collections BitDAOGovernanceV2 as bitdaogovernance
 collections LDAO
 end box
@@ -130,7 +134,27 @@ alt#Gold #DarkSeaGreen trace
   bitdaoadmin <-- bitdaogovernance: TxHash
 end
 
+newpage
 
+autonumber "Upgrades:[00]"
+
+== Upgrades ==
+
+alice -> forum: create forum upgrade proposal
+alice <- guarantor: positive/negative feedback
+
+community -> community: delegate role based votes
+
+alice -> bitdaogovernance: if (roles) submit upgrade proposal
+community -> bitdaogovernance: roles voting
+
+bitdaoadmin -> bitdaogovernance: show roles voting result
+bitdaoadmin <-- bitdaogovernance: pass/fail
+
+executor <-- bitdaogovernance: execute proposal
+executor -> governanceproxy: set new bitdaogovernance implementation
+executor -> treasuryproxy: set new bitdaotreasury implementation
+executor -> executorproxy: set new executor implementation
 
 
 @enduml


### PR DESCRIPTION
Upgrades flow that allows send proposals to set new proxy implementations for timelock, governance, treasury contracts and potentially other contracts that will be part of the governance framework. As logically for that, voting occurs on-chain and roles based, then in case of successful voting, current executor or BitDAOAdmin based sets new implementations for contracts.